### PR TITLE
Use fixed sized integers for portability.

### DIFF
--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 //
 // Global parameters/defines.

--- a/src/m_fixed.h
+++ b/src/m_fixed.h
@@ -23,11 +23,7 @@
 #ifndef __M_FIXED__
 #define __M_FIXED__
 
-
-#ifdef __GNUG__
-#pragma interface
-#endif
-
+#include <inttypes.h>
 
 //
 // Fixed point, 32bit as 16.16.
@@ -35,7 +31,7 @@
 #define FRACBITS    16
 #define FRACUNIT    (1<<FRACBITS)
 
-typedef int fixed_t;
+typedef int32_t fixed_t;
 
 fixed_t FixedMul  (fixed_t a, fixed_t b);
 fixed_t FixedDiv  (fixed_t a, fixed_t b);

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -72,7 +72,6 @@ typedef struct
 {
   fixed_t x;
   fixed_t y;
-
 } vertex_t;
 
 
@@ -88,10 +87,9 @@ struct line_s;
 typedef struct
 {
   thinker_t   thinker;  // not used for anything
-  fixed_t   x;
-  fixed_t   y;
-  fixed_t   z;
-
+  fixed_t     x;
+  fixed_t     y;
+  fixed_t     z;
 } degenmobj_t;
 
 //
@@ -100,42 +98,38 @@ typedef struct
 //
 typedef struct
 {
-  fixed_t floorheight;
-  fixed_t ceilingheight;
-  short floorpic;
-  short ceilingpic;
-  short lightlevel;
-  short special;
-  short tag;
+  fixed_t         floorheight;
+  fixed_t         ceilingheight;
+  int16_t         floorpic;
+  int16_t         ceilingpic;
+  int16_t         lightlevel;
+  int16_t         special;
+  int16_t         tag;
 
   // 0 = untraversed, 1,2 = sndlines -1
-  int   soundtraversed;
+  int32_t         soundtraversed;
 
   // thing that made a sound (or null)
-  mobj_t* soundtarget;
+  mobj_t*         soundtarget;
 
   // mapblock bounding box for height changes
-  int   blockbox[4];
+  int32_t         blockbox[4];
 
   // origin for any sounds played by the sector
-  degenmobj_t soundorg;
+  degenmobj_t     soundorg;
 
   // if == validcount, already checked
-  int   validcount;
+  int32_t         validcount;
 
   // list of mobjs in sector
-  mobj_t* thinglist;
+  mobj_t*         thinglist;
 
   // thinker_t for reversable actions
-  void* specialdata;
+  void*           specialdata;
 
-  int     linecount;
+  int32_t         linecount;
   struct line_s** lines;  // [linecount] size
-
 } sector_t;
-
-
-
 
 //
 // The SideDef.
@@ -144,23 +138,20 @@ typedef struct
 typedef struct
 {
   // add this to the calculated texture column
-  fixed_t textureoffset;
+  fixed_t   textureoffset;
 
   // add this to the calculated texture top
-  fixed_t rowoffset;
+  fixed_t   rowoffset;
 
   // Texture indices.
   // We do not maintain names here.
-  short toptexture;
-  short bottomtexture;
-  short midtexture;
+  int16_t   toptexture;
+  int16_t   bottomtexture;
+  int16_t   midtexture;
 
   // Sector the SideDef is facing.
   sector_t* sector;
-
 } side_t;
-
-
 
 //
 // Move clipping aid for LineDefs.
@@ -171,51 +162,45 @@ typedef enum
   ST_VERTICAL,
   ST_POSITIVE,
   ST_NEGATIVE
-
 } slopetype_t;
-
-
 
 typedef struct line_s
 {
   // Vertices, from v1 to v2.
-  vertex_t* v1;
-  vertex_t* v2;
+  vertex_t*   v1;
+  vertex_t*   v2;
 
   // Precalculated v2 - v1 for side checking.
-  fixed_t dx;
-  fixed_t dy;
+  fixed_t     dx;
+  fixed_t     dy;
 
   // Animation related.
-  short flags;
-  short special;
-  short tag;
+  int16_t     flags;
+  int16_t     special;
+  int16_t     tag;
 
   // Visual appearance: SideDefs.
   //  sidenum[1] will be -1 if one sided
-  short sidenum[2];
+  int16_t     sidenum[2];
 
   // Neat. Another bounding box, for the extent
   //  of the LineDef.
-  fixed_t bbox[4];
+  fixed_t     bbox[4];
 
   // To aid move clipping.
   slopetype_t slopetype;
 
   // Front and back sector.
   // Note: redundant? Can be retrieved from SideDefs.
-  sector_t* frontsector;
-  sector_t* backsector;
+  sector_t*   frontsector;
+  sector_t*   backsector;
 
   // if == validcount, already checked
-  int   validcount;
+  int32_t     validcount;
 
   // thinker_t for reversable actions
-  void* specialdata;
+  void*       specialdata;
 } line_t;
-
-
-
 
 //
 // A SubSector.
@@ -227,12 +212,9 @@ typedef struct line_s
 typedef struct subsector_s
 {
   sector_t* sector;
-  short numlines;
-  short firstline;
-
+  int16_t   numlines;
+  int16_t   firstline;
 } subsector_t;
-
-
 
 //
 // The LineSeg.
@@ -242,22 +224,19 @@ typedef struct
   vertex_t* v1;
   vertex_t* v2;
 
-  fixed_t offset;
+  fixed_t   offset;
 
-  angle_t angle;
+  angle_t   angle;
 
-  side_t* sidedef;
-  line_t* linedef;
+  side_t*   sidedef;
+  line_t*   linedef;
 
   // Sector references.
   // Could be retrieved from linedef, too.
   // backsector is NULL for one sided lines
   sector_t* frontsector;
   sector_t* backsector;
-
 } seg_t;
-
-
 
 //
 // BSP node.
@@ -265,21 +244,17 @@ typedef struct
 typedef struct
 {
   // Partition line.
-  fixed_t x;
-  fixed_t y;
-  fixed_t dx;
-  fixed_t dy;
+  fixed_t  x;
+  fixed_t  y;
+  fixed_t  dx;
+  fixed_t  dy;
 
   // Bounding box for each child.
-  fixed_t bbox[2][4];
+  fixed_t  bbox[2][4];
 
   // If NF_SUBSECTOR its a subsector.
-  unsigned short children[2];
-
+  uint16_t children[2];
 } node_t;
-
-
-
 
 // posts are runs of non masked source pixels
 typedef struct
@@ -313,40 +288,34 @@ typedef post_t  column_t;
 // Could even us emore than 32 levels.
 typedef byte  lighttable_t;
 
-
-
-
 //
 // ?
 //
 typedef struct drawseg_s
 {
-  seg_t*    curline;
-  int     x1;
-  int     x2;
+  seg_t*   curline;
+  int32_t  x1;
+  int32_t  x2;
 
-  fixed_t   scale1;
-  fixed_t   scale2;
-  fixed_t   scalestep;
+  fixed_t  scale1;
+  fixed_t  scale2;
+  fixed_t  scalestep;
 
   // 0=none, 1=bottom, 2=top, 3=both
-  int     silhouette;
+  int32_t  silhouette;
 
   // do not clip sprites above this
-  fixed_t   bsilheight;
+  fixed_t  bsilheight;
 
   // do not clip sprites below this
-  fixed_t   tsilheight;
+  fixed_t  tsilheight;
 
   // Pointers to lists for sprite clipping,
   //  all three adjusted so [x1] is first value.
-  short*    sprtopclip;
-  short*    sprbottomclip;
-  short*    maskedtexturecol;
-
+  int16_t* sprtopclip;
+  int16_t* sprbottomclip;
+  int16_t* maskedtexturecol;
 } drawseg_t;
-
-
 
 // Patches.
 // A patch holds one or more columns.
@@ -355,19 +324,13 @@ typedef struct drawseg_s
 // of patches.
 typedef struct
 {
-  short   width;    // bounding box size
-  short   height;
-  short   leftoffset; // pixels to the left of origin
-  short   topoffset;  // pixels below the origin
-  int     columnofs[8]; // only [width] used
+  int16_t width;    // bounding box size
+  int16_t height;
+  int16_t leftoffset; // pixels to the left of origin
+  int16_t topoffset;  // pixels below the origin
+  int32_t columnofs[8]; // only [width] used
   // the [0] is &columnofs[width]
 } patch_t;
-
-
-
-
-
-
 
 // A vissprite_t is a thing
 //  that will be drawn during a refresh.
@@ -378,33 +341,33 @@ typedef struct vissprite_s
   struct vissprite_s* prev;
   struct vissprite_s* next;
 
-  int     x1;
-  int     x2;
+  int32_t             x1;
+  int32_t             x2;
 
   // for line side calculation
-  fixed_t   gx;
-  fixed_t   gy;
+  fixed_t             gx;
+  fixed_t             gy;
 
   // global bottom / top for silhouette clipping
-  fixed_t   gz;
-  fixed_t   gzt;
+  fixed_t             gz;
+  fixed_t             gzt;
 
   // horizontal position of x1
-  fixed_t   startfrac;
+  fixed_t             startfrac;
 
-  fixed_t   scale;
+  fixed_t             scale;
 
   // negative if flipped
-  fixed_t   xiscale;
+  fixed_t             xiscale;
 
-  fixed_t   texturemid;
-  int     patch;
+  fixed_t             texturemid;
+  int32_t             patch;
 
   // for color translation and shadow draw,
   //  maxbright frames as well
-  lighttable_t* colormap;
+  lighttable_t*       colormap;
 
-  int     mobjflags;
+  int32_t             mobjflags;
 
 } vissprite_t;
 
@@ -432,7 +395,7 @@ typedef struct
   boolean rotate;
 
   // Lump to use for view angles 0-7.
-  short lump[8];
+  int16_t lump[8];
 
   // Flip bit (1 = flip) to use for view angles 0-7.
   byte  flip[8];
@@ -447,7 +410,7 @@ typedef struct
 //
 typedef struct
 {
-  int     numframes;
+  int32_t         numframes;
   spriteframe_t*  spriteframes;
 
 } spritedef_t;
@@ -460,27 +423,24 @@ typedef struct
 typedef struct
 {
   fixed_t   height;
-  int     picnum;
-  int     lightlevel;
-  int     minx;
-  int     maxx;
+  int32_t   picnum;
+  int32_t   lightlevel;
+  int32_t   minx;
+  int32_t   maxx;
 
   // leave pads for [minx-1]/[maxx+1]
 
-  byte    pad1;
+  byte      pad1;
   // Here lies the rub for all
   //  dynamic resize/change of resolution.
-  byte    top[SCREENWIDTH];
-  byte    pad2;
-  byte    pad3;
+  byte      top[SCREENWIDTH];
+  byte      pad2;
+  byte      pad3;
   // See above.
-  byte    bottom[SCREENWIDTH];
-  byte    pad4;
+  byte      bottom[SCREENWIDTH];
+  byte      pad4;
 
 } visplane_t;
-
-
-
 
 #endif
 //-----------------------------------------------------------------------------

--- a/src/tables.h
+++ b/src/tables.h
@@ -71,7 +71,7 @@ extern fixed_t    finetangent[FINEANGLES / 2];
 #define SLOPEBITS   11
 #define DBITS     (FRACBITS-SLOPEBITS)
 
-typedef unsigned angle_t;
+typedef uint32_t angle_t;
 
 
 // Effective size is 2049;

--- a/src/w_wad.h
+++ b/src/w_wad.h
@@ -23,11 +23,7 @@
 #ifndef __W_WAD__
 #define __W_WAD__
 
-
-#ifdef __GNUG__
-#pragma interface
-#endif
-
+#include <inttypes.h>
 
 //
 // TYPES
@@ -36,18 +32,16 @@ typedef struct
 {
   // Should be "IWAD" or "PWAD".
   char    identification[4];
-  int     numlumps;
-  int     infotableofs;
-
+  int32_t numlumps;
+  int32_t infotableofs;
 } wadinfo_t;
 
 
 typedef struct
 {
-  int     filepos;
-  int     size;
+  int32_t filepos;
+  int32_t size;
   char    name[8];
-
 } filelump_t;
 
 //
@@ -55,10 +49,10 @@ typedef struct
 //
 typedef struct
 {
-  char  name[8];
-  int   handle;
-  int   position;
-  int   size;
+  char    name[8];
+  int32_t handle;
+  int32_t position;
+  int32_t size;
 } lumpinfo_t;
 
 


### PR DESCRIPTION
DOOM reads various C structures directly from WAD files assuming that
integers are 32 bit, which is not the fact on 64 bit machines. Use fixed
sized integers in various structs to fix the issue.
